### PR TITLE
prefer emitter.listenerCount instance method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,4 +13,10 @@ listenerCount = listenerCount || function (ee, event) {
   }
 }
 
-module.exports = listenerCount
+module.exports = function (ee, event) {
+  if (ee.listenerCount) {
+    return ee.listenerCount(event)
+  } else {
+    return listenerCount(ee, event)
+  }
+}


### PR DESCRIPTION
EventEmitter.listenerCount is now deprecated, and the method on individual instances should now be use.

This avoids deprecation warnings being printed to stderr, and protects against future removal of the method.

Source:
  https://nodejs.org/api/events.html#events_eventemitter_listenercount_emitter_eventname
